### PR TITLE
Use the /api/id endpoint instead of /resource for consistency

### DIFF
--- a/lib/exsoda/reader.ex
+++ b/lib/exsoda/reader.ex
@@ -47,7 +47,7 @@ defmodule Exsoda.Reader do
 
       query = URI.encode_query(state.query)
 
-      stream = "#{base}/resource/#{state.fourfour}.csv?#{query}"
+      stream = "#{base}/id/#{state.fourfour}.csv?#{query}"
       |> HTTPoison.get(Http.headers(state), [{:stream_to, self} | Http.opts(state)])
       |> as_line_stream
       |> CSV.parse_stream(headers: false)

--- a/lib/exsoda/writer.ex
+++ b/lib/exsoda/writer.ex
@@ -58,7 +58,7 @@ defmodule Exsoda.Writer do
   end
 
   defp do_run(%Upsert{} = u, w) do
-    post("/resource/#{u.fourfour}.json", w, u.rows)
+    post("/id/#{u.fourfour}.json", w, u.rows)
   end
 
   def run(%Write{} = w) do


### PR DESCRIPTION
The Upsert/SODA resource API is a rewrite of /api/id.
For consistency of the request paths (all other public api
paths are prepended with /api), it seems reasonable to just use
/api/id instead of /resource.