### PR TITLE
Allow for spoof auth

### DIFF
--- a/lib/exsoda/configuration_reader.ex
+++ b/lib/exsoda/configuration_reader.ex
@@ -49,11 +49,12 @@ defmodule Exsoda.ConfigurationReader do
   end
 
   defp get(path, r, json_opts) do
-    with {:ok, base} <- Http.base_url(r) do
+    with {:ok, base} <- Http.base_url(r),
+         {:ok, options} <- Http.opts(r) do
       HTTPoison.get(
         "#{base}#{path}",
         Http.headers(r),
-        Http.opts(r)
+        options
       ) |> Http.as_json(json_opts)
     end
   end

--- a/lib/exsoda/reader.ex
+++ b/lib/exsoda/reader.ex
@@ -28,9 +28,10 @@ defmodule Exsoda.Reader do
   end
 
   def get_view(%Query{fourfour: fourfour} = state) do
-    with {:ok, base} <- Http.base_url(state) do
+    with {:ok, base} <- Http.base_url(state),
+         {:ok, options} <- Http.opts(state) do
       "#{base}/views/#{fourfour}.json"
-      |> HTTPoison.get(Http.headers(state), Http.opts(state))
+      |> HTTPoison.get(Http.headers(state), options)
       |> Http.as_json
     end
   end
@@ -43,12 +44,13 @@ defmodule Exsoda.Reader do
 
   def run(%Query{} = state) do
     with {:ok, columns} <- get_columns(state),
-      {:ok, base} <- Http.base_url(state) do
+         {:ok, base} <- Http.base_url(state),
+         {:ok, options} <- Http.opts(state) do
 
       query = URI.encode_query(state.query)
 
       stream = "#{base}/id/#{state.fourfour}.csv?#{query}"
-      |> HTTPoison.get(Http.headers(state), [{:stream_to, self} | Http.opts(state)])
+      |> HTTPoison.get(Http.headers(state), [{:stream_to, self} | options])
       |> as_line_stream
       |> CSV.parse_stream(headers: false)
       |> Stream.transform(nil,

--- a/test/configuration_reader_test.exs
+++ b/test/configuration_reader_test.exs
@@ -11,7 +11,9 @@ defmodule ExsodaTest.ConfigurationReader do
         account: Config.get(:exsoda, :account),
         domain: "cheetah.test-socrata.com",
         recv_timeout: 5000,
-        timeout: 5000
+        timeout: 5000,
+        api_root: "/api",
+        protocol: "https"
       },
       operations: [query]
     }

--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -3,17 +3,27 @@ defmodule ExsodaTest.Http do
   alias Exsoda.Http
 
   test "can make a base url" do
-    actual = Http.base_url(%{opts: %{domain: "foo"}})
+    actual = Http.base_url(%{opts: %{domain: "foo", api_root: "/api", protocol: "https"}})
     assert actual == {:ok, "https://foo/api"}
   end
 
   test "can make a base url with explicit host" do
-    actual = Http.base_url(%{opts: %{host: "foo"}})
+    actual = Http.base_url(%{opts: %{host: "foo", api_root: "/api", protocol: "https"}})
     assert actual == {:ok, "https://foo/api"}
   end
 
   test "can make a base url with function as host" do
-    actual = Http.base_url(%{opts: %{host: fn -> {:ok, "foo"} end}})
+    actual = Http.base_url(%{opts: %{host: fn -> {:ok, "foo"} end, api_root: "/api", protocol: "https"}})
     assert actual == {:ok, "https://foo/api"}
+  end
+
+  test "respects the api_root passed in" do
+    actual = Http.base_url(%{opts: %{host: "foo", api_root: "", protocol: "https"}})
+    assert actual == {:ok, "https://foo"}
+  end
+
+  test "respects the protocol passed in" do
+    actual = Http.base_url(%{opts: %{host: "foo", api_root: "", protocol: "http"}})
+    assert actual == {:ok, "http://foo"}
   end
 end

--- a/test/reader_test.exs
+++ b/test/reader_test.exs
@@ -11,7 +11,9 @@ defmodule ExsodaTest.Reader do
         account: Config.get(:exsoda, :account),
         domain: "cheetah.test-socrata.com",
         recv_timeout: 5000,
-        timeout: 5000
+        timeout: 5000,
+        api_root: "/api",
+        protocol: "https"
       },
       fourfour: "four-four",
       query: query}

--- a/test/writer_test.exs
+++ b/test/writer_test.exs
@@ -175,6 +175,7 @@ defmodule ExsodaTest.Writer do
     ]
   end
 
+  # This test requires being on the us-west-2 VPN to pass
   test "can spoof a user during a write request" do
     spoofee_email = "test-viewer@socrata.com"
     spoof = %{


### PR DESCRIPTION
Allow for spoof auth, which gets a cookie from core to use for each request
As a consequence, forming options in Http module has a change of failure, and now returns an :ok/:error tuple. api_root and protocol are also not both settable through passed options, not just config.

Also this test will only pass if you're on staging VPN :(