### PR TITLE
Adds support for user agent and x-socrata-request-id headers

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,3 +6,4 @@ config :exsoda,
   account: {:system, "SOCRATA_LOCAL_USER"},
   password: {:system, "SOCRATA_LOCAL_PASS"},
   hackney_opts: [:insecure]
+  

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,4 +3,6 @@ use Mix.Config
 config :exsoda,
   account: {:system, "SOCRATA_USER"},
   password: {:system, "SOCRATA_PASSWORD"},
-  domain: "cheetah.test-socrata.com"
+  domain: "cheetah.test-socrata.com",
+  user_agent: "exsoda",
+  request_id: "fake-uuid"

--- a/lib/exsoda/http.ex
+++ b/lib/exsoda/http.ex
@@ -35,10 +35,12 @@ defmodule Exsoda.Http do
     {:ok, make_url(domain, api_root, protocol)}
   end
 
-  def headers(%{opts: %{domain: domain}}) do
+  def headers(%{opts: %{domain: domain, user_agent: user_agent, request_id: request_id}}) do
     [
+      {"User-Agent", user_agent},
       {"Content-Type", "application/json"},
-      {"X-Socrata-Host", domain}
+      {"X-Socrata-Host", domain},
+      {"X-Socrata-RequestId", request_id}
     ]
   end
 
@@ -114,6 +116,8 @@ defmodule Exsoda.Http do
     |> add_opt(user_opts, :password)
     |> add_opt(user_opts, :host)
     |> add_opt(user_opts, :cookie)
+    |> add_opt(user_opts, :user_agent, "exsoda")
+    |> add_opt(user_opts, :request_id, UUID.uuid4)
     |> add_opt(user_opts, :api_root, "/api")
     |> add_opt(user_opts, :protocol, "https")
     |> add_opt(user_opts, :recv_timeout, 5_000)

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,8 @@ defmodule Exsoda.Mixfile do
       {:httpoison, "~> 0.11.0"},
       {:poison, "~> 2.2.0"},
       {:nimble_csv, "~> 0.1.0"},
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:uuid, "~> 1.1"}
     ]
   end
 end

--- a/test/configuration_reader_test.exs
+++ b/test/configuration_reader_test.exs
@@ -13,7 +13,9 @@ defmodule ExsodaTest.ConfigurationReader do
         recv_timeout: 5000,
         timeout: 5000,
         api_root: "/api",
-        protocol: "https"
+        protocol: "https",
+        user_agent: "exsoda",
+        request_id: "fake-uuid"
       },
       operations: [query]
     }

--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -26,4 +26,12 @@ defmodule ExsodaTest.Http do
     actual = Http.base_url(%{opts: %{host: "foo", api_root: "", protocol: "http"}})
     assert actual == {:ok, "http://foo"}
   end
+
+  test "can override user_agent and request_id options" do
+    base_options = Http.options([{}])
+    overriden_options = Http.options([{:user_agent, "test-agent"}, {:request_id, "different-fake-uuid"}])
+    assert overriden_options.user_agent == "test-agent"
+    assert overriden_options.request_id == "different-fake-uuid"
+
+  end
 end

--- a/test/reader_test.exs
+++ b/test/reader_test.exs
@@ -13,7 +13,9 @@ defmodule ExsodaTest.Reader do
         recv_timeout: 5000,
         timeout: 5000,
         api_root: "/api",
-        protocol: "https"
+        protocol: "https",
+        user_agent: "exsoda",
+        request_id: "fake-uuid"
       },
       fourfour: "four-four",
       query: query}


### PR DESCRIPTION
defaults are "exsoda" and a randomly generated uuid
can be set by passing in or at a configuration level