### PR TITLE
encode filename

### DIFF
--- a/lib/exsoda/writer.ex
+++ b/lib/exsoda/writer.ex
@@ -251,7 +251,7 @@ defmodule Exsoda.Writer do
 
       def run(%SetBlobForDraft{fourfour: fourfour, byte_stream: byte_stream, filename: filename}, o) do
         body = {:stream, byte_stream}
-        headers = %{content_type: "application/octet-stream", filename: filename}
+        headers = %{content_type: "application/octet-stream", filename: Http.encode(filename)}
         ops = %{opts: Map.merge(o.opts, headers)}
         url = "/imports2?method=setBlobForDraft&saveUnderViewUid=#{Http.encode(fourfour)}"
         Http.post(url, ops, body)
@@ -270,7 +270,7 @@ defmodule Exsoda.Writer do
       end
       def run(%ReplaceBlob{fourfour: fourfour, byte_stream: byte_stream, filename: filename}, o) do
         body = {:stream, byte_stream}
-        headers = %{content_type: "application/octet-stream", filename: filename}
+        headers = %{content_type: "application/octet-stream", filename: Http.encode(filename)}
         ops = %{opts: Map.merge(o.opts, headers)}
         url = "/views/#{Http.encode(fourfour)}?method=replaceBlob"
         Http.post(url, ops, body)
@@ -284,7 +284,7 @@ defmodule Exsoda.Writer do
     defimpl Execute, for: __MODULE__ do
       def run(%UploadAttachment{fourfour: fourfour, byte_stream: byte_stream, filename: filename}, o) do
         body = {:stream, byte_stream}
-        headers = %{content_type: "application/octet-stream", filename: filename}
+        headers = %{content_type: "application/octet-stream", filename: Http.encode(filename)}
         ops = %{opts: Map.merge(o.opts, headers)}
         url = "/views/#{Http.encode(fourfour)}/files.txt"
         Http.post(url, ops, body)

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Exsoda.Mixfile do
 
   def project do
     [app: :exsoda,
-     version: "4.0.21",
+     version: "4.0.23",
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
the file reading methods in core URIdecode values passed as X-File-Name, so we should encode them when we send them, so it's not upset when they contain things like %.