### PR TITLE
allow content type on blob setting

### DIFF
--- a/lib/exsoda/http.ex
+++ b/lib/exsoda/http.ex
@@ -78,7 +78,7 @@ defmodule Exsoda.Http do
       spoofer_email: spoofer_email,
       spoofer_password: spoofer_password
     },
-    domain: domain,
+    domain: _domain,
     request_id: request_id} = opts) do
     body = [{"username", "#{spoofee_email} #{spoofer_email}"}, {"password", "#{spoofer_password}"}]
     headers = [{"Content-Type", "application/x-www-form-urlencoded"} | headers(%{opts: opts})]

--- a/lib/exsoda/writer.ex
+++ b/lib/exsoda/writer.ex
@@ -252,7 +252,7 @@ defmodule Exsoda.Writer do
   end
 
   defmodule SetBlobForDraft do
-    defstruct fourfour: nil, filename: nil, file_path: nil, byte_stream: nil
+    defstruct fourfour: nil, filename: nil, file_path: nil, byte_stream: nil, content_type: nil
 
     defimpl Execute, for: __MODULE__ do
       def run(%SetBlobForDraft{fourfour: fourfour, file_path: file_path}, o) when is_binary(file_path) do
@@ -261,9 +261,9 @@ defmodule Exsoda.Writer do
         Http.post(url, o, body)
       end
 
-      def run(%SetBlobForDraft{fourfour: fourfour, byte_stream: byte_stream, filename: filename}, o) do
+      def run(%SetBlobForDraft{fourfour: fourfour, byte_stream: byte_stream, filename: filename, content_type: content_type}, o) do
         body = {:stream, byte_stream}
-        headers = %{content_type: "application/octet-stream", filename: Http.encode(filename)}
+        headers = %{content_type: content_type, filename: Http.encode(filename)}
         ops = %{opts: Map.merge(o.opts, headers)}
         url = "/imports2?method=setBlobForDraft&saveUnderViewUid=#{Http.encode(fourfour)}"
         Http.post(url, ops, body)
@@ -272,7 +272,7 @@ defmodule Exsoda.Writer do
   end
 
   defmodule ReplaceBlob do
-    defstruct fourfour: nil, filename: nil, file_path: nil, byte_stream: nil
+    defstruct fourfour: nil, filename: nil, file_path: nil, byte_stream: nil, content_type: nil
 
     defimpl Execute, for: __MODULE__ do
       def run(%ReplaceBlob{fourfour: fourfour, file_path: file_path}, o) when is_binary(file_path) do
@@ -280,9 +280,9 @@ defmodule Exsoda.Writer do
         url = "/views/#{Http.encode(fourfour)}?method=replaceBlob"
         Http.post(url, o, body)
       end
-      def run(%ReplaceBlob{fourfour: fourfour, byte_stream: byte_stream, filename: filename}, o) do
+      def run(%ReplaceBlob{fourfour: fourfour, byte_stream: byte_stream, filename: filename, content_type: content_type}, o) do
         body = {:stream, byte_stream}
-        headers = %{content_type: "application/octet-stream", filename: Http.encode(filename)}
+        headers = %{content_type: content_type, filename: Http.encode(filename)}
         ops = %{opts: Map.merge(o.opts, headers)}
         url = "/views/#{Http.encode(fourfour)}?method=replaceBlob"
         Http.post(url, ops, body)
@@ -291,12 +291,12 @@ defmodule Exsoda.Writer do
   end
 
   defmodule UploadAttachment do
-    defstruct [:fourfour, :byte_stream, :filename]
+    defstruct [:fourfour, :byte_stream, :filename, :content_type]
 
     defimpl Execute, for: __MODULE__ do
-      def run(%UploadAttachment{fourfour: fourfour, byte_stream: byte_stream, filename: filename}, o) do
+      def run(%UploadAttachment{fourfour: fourfour, byte_stream: byte_stream, filename: filename, content_type: content_type}, o) do
         body = {:stream, byte_stream}
-        headers = %{content_type: "application/octet-stream", filename: Http.encode(filename)}
+        headers = %{content_type: content_type, filename: Http.encode(filename)}
         ops = %{opts: Map.merge(o.opts, headers)}
         url = "/views/#{Http.encode(fourfour)}/files.txt"
         Http.post(url, ops, body)
@@ -382,18 +382,18 @@ defmodule Exsoda.Writer do
   def set_blob_for_draft(%Operations{} = o, fourfour, file_path) when is_binary(file_path) do
     prepend(%SetBlobForDraft{fourfour: fourfour, file_path: file_path}, o)
   end
-  def set_blob_for_draft(%Operations{} = o, fourfour, byte_stream, filename) when is_map(byte_stream) do
-    prepend(%SetBlobForDraft{fourfour: fourfour, byte_stream: byte_stream, filename: filename}, o)
+  def set_blob_for_draft(%Operations{} = o, fourfour, byte_stream, filename, content_type \\ "application/octet-stream") when is_map(byte_stream) do
+    prepend(%SetBlobForDraft{fourfour: fourfour, byte_stream: byte_stream, filename: filename, content_type: content_type}, o)
   end
 
   def replace_blob(%Operations{} = o, fourfour, file_path) when is_binary(file_path) do
     prepend(%ReplaceBlob{fourfour: fourfour, file_path: file_path}, o)
   end
-  def replace_blob(%Operations{} = o, fourfour, byte_stream, filename) when is_map(byte_stream) do
-    prepend(%ReplaceBlob{fourfour: fourfour, byte_stream: byte_stream, filename: filename}, o)
+  def replace_blob(%Operations{} = o, fourfour, byte_stream, filename, content_type \\ "application/octet-stream") when is_map(byte_stream) do
+    prepend(%ReplaceBlob{fourfour: fourfour, byte_stream: byte_stream, filename: filename, content_type: content_type}, o)
   end
 
-  def upload_attachment(%Operations{} = o, fourfour, byte_stream, filename) do
-    prepend(%UploadAttachment{fourfour: fourfour, byte_stream: byte_stream, filename: filename}, o)
+  def upload_attachment(%Operations{} = o, fourfour, byte_stream, filename, content_type \\ "application/octet-stream") do
+    prepend(%UploadAttachment{fourfour: fourfour, byte_stream: byte_stream, filename: filename, content_type: content_type}, o)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Exsoda.Mixfile do
 
   def project do
     [app: :exsoda,
-     version: "4.0.29",
+     version: "4.0.30",
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/writer_test.exs
+++ b/test/writer_test.exs
@@ -429,7 +429,8 @@ defmodule ExsodaTest.Writer do
       %SetBlobForDraft{
         fourfour: "meow-meow",
         byte_stream: byte_stream,
-        filename: filename
+        filename: filename,
+        content_type: "application/octet-stream"
       }]
   end
 
@@ -443,7 +444,8 @@ defmodule ExsodaTest.Writer do
       %ReplaceBlob{
         fourfour: "meow-meow",
         byte_stream: byte_stream,
-        filename: filename
+        filename: filename,
+        content_type: "application/octet-stream"
       }]
   end
 
@@ -457,7 +459,8 @@ defmodule ExsodaTest.Writer do
       %UploadAttachment{
         fourfour: "meow-meow",
         byte_stream: byte_stream,
-        filename: filename
+        filename: filename,
+        content_type: "application/octet-stream"
       }]
   end
 


### PR DESCRIPTION
Part of ongoing work that will allow dsmapi to pass the content-type of the file to core, to ensure that they're in agreement about it. (Otherwise our blobfile previews will be misleading)