### PR TITLE
Allow (url) params passing

### DIFF
--- a/lib/exsoda/http.ex
+++ b/lib/exsoda/http.ex
@@ -175,6 +175,7 @@ defmodule Exsoda.Http do
     |> add_opt(user_opts, :app_token, nil)
     |> add_opt(user_opts, :recv_timeout, 5_000)
     |> add_opt(user_opts, :timeout, 5_000)
+    |> add_opt(user_opts, :params, user_opts[:params])
   end
 
   def as_json(result), do: as_json(result, [])
@@ -224,11 +225,12 @@ defmodule Exsoda.Http do
     with {:ok, base} <- base_url(op),
          {:ok, http_options} <- http_opts(op) do
       Logger.debug("Posting with request_id: #{op.opts.request_id}")
+      http_options_with_params = Keyword.put_new(http_options, :params, op.opts[:params])
       HTTPoison.post(
         "#{base}#{path}",
         body,
         headers(op),
-        http_options
+        http_options_with_params
       )
       |> maybe_202(path, op, fn -> post(path, op, body) end)
     end

--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -33,4 +33,11 @@ defmodule ExsodaTest.Http do
     assert overriden_options.request_id == "different-fake-uuid"
 
   end
+
+  test "can supply url parameters" do
+    overriden_options = Http.options([{:user_agent, "test-agent"}, {:request_id, "different-fake-uuid"}, {:params, %{"p1" => "v1", "p2" =>"v2"}}])
+    assert overriden_options.user_agent == "test-agent"
+    assert overriden_options.request_id == "different-fake-uuid"
+    assert overriden_options.params == %{"p1" => "v1", "p2" =>"v2"}
+  end
 end

--- a/test/writer_test.exs
+++ b/test/writer_test.exs
@@ -46,6 +46,16 @@ defmodule ExsodaTest.Writer do
     assert options.timeout == 2000
   end
 
+  test "can write with parameters" do
+    options = Writer.write([params: %{"k1" => "v1", "k2" => "v2"}, recv_timeout: 8000, timeout: 2000])
+              |> Writer.create("a name", %{description: "describes"})
+              |> Map.get(:opts)
+
+    assert options.recv_timeout == 8000
+    assert options.timeout == 2000
+    assert options.params == %{"k1" => "v1", "k2" => "v2"}
+  end
+
   test "running CreateView returns list of results" do
     results = Writer.write()
     |> Writer.create("a name", %{description: "describes"})


### PR DESCRIPTION
Example:
Exsoda.Writer.write(domain: "scgc", params: %{deleted_at: "2021-10-02"}) |> Exsoda.Writer.create("a name", %{description: "describes"}) |> Exsoda.Writer.run