### PR TITLE
EN-60097 Use guidance_v2 for approvals

### DIFF
--- a/lib/exsoda/approvals.ex
+++ b/lib/exsoda/approvals.ex
@@ -12,7 +12,7 @@ defmodule Exsoda.Approvals do
     defimpl Execute, for: __MODULE__ do
       def run(%Guidance{} = gu, o) do
         query = URI.encode_query(%{
-            method: "guidance",
+            method: "guidance_v2",
             assetId: gu.catalog_revision_id
         })
         Http.get("/views/#{Http.encode(gu.fourfour)}/approvals/?#{query}", o)


### PR DESCRIPTION
We now have a `guidance_v2`, which we'll be using for internal approvals down the road & we're changing all uses of the old `guidance` endpoint to point to the new one instead.